### PR TITLE
Improve input includes for publication

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ OpenACC:
 - PGI Compiler 19.10 or newer (later renamed as NVIDIA HPC SDK)
 - CUDA v9.0 or newer
 - Pascal or newer GPUs
-- With OmpSs-2, use this experimental version of the [Nanos6 Runtime](https://github.com/epeec/nanos6-openacc) (get-queue-affinity branch)
+- With OmpSs-2, use this experimental version of the [Nanos6 Runtime](https://github.com/epeec/nanos6-openacc) (get-queue-affinity-update2021 branch)
 
 
 ### Compilation Flags

--- a/ompss2_openacc/main.c
+++ b/ompss2_openacc/main.c
@@ -28,10 +28,17 @@
 #include "timer.h"
 
 // Simulation parameters (naming scheme : <type>-<number of particles>-<grid size x>-<grid size y>.c)
-//#include "input/weibel-2000-151M-2048-2048.c"
-#include "input/lwfa-4000-16M-2000-512.c"
-//#include "input/warm-2000-538M-2900-2900.c"
-// #include "input/weibel-500-67M-512-512.c"
+
+/* Strong scaling */
+#include "input/weibel-2000-151M-2048-2048.c"
+//#include "input/lwfa-8000-74M-4000-2048.c"
+
+/* Weak scaling */
+//#include "input/weak/weibel-2000-151M-2048-2048.c" /* 1 GPU  */
+//#include "input/weak/weibel-2000-303M-2900-2900.c" /* 2 GPUs */
+//#include "input/weak/weibel-2000-467M-3600-3600.c" /* 3 GPUs */
+//#include "input/weak/weibel-2000-604M-4096-4096.c" /* 4 GPUs */
+
 
 #pragma oss assert("version.dependencies==regions")
 int main(int argc, const char *argv[])

--- a/openacc/main.c
+++ b/openacc/main.c
@@ -30,11 +30,16 @@
 #include "utilities.h"
 
 // Simulation parameters (naming scheme : <type>-<number of particles>-<grid size x>-<grid size y>.c)
-#include "input/weibel-500-67M-512-512.c"
-//  #include "input/lwfa-4000-16M-2000-512.c"
-//#include "input/warm-500-67M-512-512.c"
-//#include "input/weibel-1000-340M-3072-3072.c"
+
+/* Strong scaling */
+#include "input/weibel-2000-151M-2048-2048.c"
 //#include "input/lwfa-8000-74M-4000-2048.c"
+
+/* Weak scaling */
+//#include "input/weak/weibel-2000-151M-2048-2048.c" /* 1 GPU  */
+//#include "input/weak/weibel-2000-303M-2900-2900.c" /* 2 GPUs */
+//#include "input/weak/weibel-2000-467M-3600-3600.c" /* 3 GPUs */
+//#include "input/weak/weibel-2000-604M-4096-4096.c" /* 4 GPUs */
 
 int main(int argc, const char *argv[])
 {


### PR DESCRIPTION
Replaced the commented out and active input file includes for OpenACC and OmpSs-2@OpenACC to make experiment replication easier.

Fixed README to point the updated (and final) nanos6 affinity-enabled branch.